### PR TITLE
stat - rendu markdown

### DIFF
--- a/stat
+++ b/stat
@@ -26,18 +26,18 @@ if __name__ == '__main__':
 
     content += '## Urls non conformes :\n\n'
     result = walk('url_result')
-    content += f'Nombres de fichiers : {result[0]}\n'
-    content += f'Nombres de remontées : {result[1]}\n\n'
+    content += f'  * Nombres de fichiers : {result[0]}\n'
+    content += f'  * Nombres de remontées : {result[1]}\n\n'
 
     content += '## Soucis de grammaire :\n\n'
     result = walk('grammar_result')
-    content += f'Nombres de fichiers : {result[0]}\n'
-    content += f'Nombres de remontées : {result[1]}\n\n'
+    content += f'  * Nombres de fichiers : {result[0]}\n'
+    content += f'  * Nombres de remontées : {result[1]}\n\n'
 
     content += '## Soucis de balises Dokuwiki :\n\n'
     result = walk('dokuwiki_result')
-    content += f'Nombres de fichiers : {result[0]}\n'
-    content += f'Nombres de remontées : {result[1]}\n\n'
+    content += f'  * Nombres de fichiers : {result[0]}\n'
+    content += f'  * Nombres de remontées : {result[1]}\n\n'
 
     with open('stats.md', 'w') as f:
         f.write(content)

--- a/stats.md
+++ b/stats.md
@@ -2,16 +2,16 @@
 
 ## Urls non conformes :
 
-Nombres de fichiers : 3530
-Nombres de remontées : 16728
+  * Nombres de fichiers : 3530
+  * Nombres de remontées : 16728
 
 ## Soucis de grammaire :
 
-Nombres de fichiers : 5650
-Nombres de remontées : 1474532
+  * Nombres de fichiers : 5650
+  * Nombres de remontées : 1474532
 
 ## Soucis de balises Dokuwiki :
 
-Nombres de fichiers : 0
-Nombres de remontées : 0
+  * Nombres de fichiers : 0
+  * Nombres de remontées : 0
 


### PR DESCRIPTION
Changer le rendu markdown du script des statistiques pour le rendre plus lisible
De

Nombres de fichiers : 3530
Nombres de remontées : 16728

  * Nombres de fichiers : 3530
  * Nombres de remontées : 16728