### PR TITLE
add token "**" for detection in auto_double_dash

### DIFF
--- a/auto_double_dash
+++ b/auto_double_dash
@@ -6,22 +6,26 @@ from wiki_c.auto_correction import BaseDetection, FormatOperation, walk
 
 DIR_URL_DESTINATION = 'dokuwiki_result'
 
+
 class DoubleDashFormatOperation(FormatOperation):
     prefix_summary = "correction tirets doubles"
-
+    
+    available_tokens = ["''","**"]
+    
     def _replace(self, doc, detected_lines):
         for line in detected_lines:
-            doc = doc.replace("''--", "''​%%--%%")
+            for token in available_tokens:
+                doc = doc.replace(token + "--", token + "%%--%%")
         return doc
 
 
 class DoubleDashDetection(BaseDetection):
-    pattern = "''-- rather than ''​%%--%%"
+    pattern = "-- rather than ​%%--%%"
 
     def _extract(self, line):
         return {
-            'before': "''--",
-            'after': "''​%%--%%"
+            'before': "--",
+            'after': "​%%--%%"
         }
 
 


### PR DESCRIPTION
Ajout d'une détection de double tiret mal formaté, à cause du token `**`

Le code n'a pas été testé/lancé