### PR TITLE
ajout de print_help pour l'utilitaire edit_grammar

### DIFF
--- a/edit_grammar
+++ b/edit_grammar
@@ -8,6 +8,13 @@ import toml
 DIR_GRAMMAR_DESTINATION = 'grammar_result'
 DIR_GRAMMAR_BLACKLIST = 'grammar_blacklist'
 
+def print_help():
+    print("edit_grammar est un utilitaire pour ajouter les faux positifs et les détecter lors du lancement du script './check'")
+    print()
+    print("edit_grammar s'utilise avec un argument correspond au nom de la page")
+    print(f"{sys.argv[0]} ppa")
+    print("\ncet utilitaire cherchera dans le dossier grammar_result")
+
 def contain_line(denied_toml, message, line_nb, col_start, col_end):
     if denied_toml == None or denied_toml == {}:
         return False
@@ -24,6 +31,15 @@ def contain_line(denied_toml, message, line_nb, col_start, col_end):
     return False
 
 if __name__ == '__main__':
+    
+    if len(sys.argv) == 1:
+        print_help()
+        exit(1)
+    
+    if sys.argv[1] == "--help" or sys.argv[1] == "-h":
+        print_help()
+        exit(0)
+    
     result = sys.argv[1]
 
     result_path = join(DIR_GRAMMAR_DESTINATION, f'{result}.txt')


### PR DESCRIPTION
Au cas où on lance edit_grammar sans paramètres, on a une erreur, j'ai fait en sorte de prendre en compte ce cas