### PR TITLE
shellcode : si le contenu débute par un saut de ligne, on l'enlève.

### DIFF
--- a/tests/checkers.py
+++ b/tests/checkers.py
@@ -61,3 +61,18 @@ class CheckerTests(unittest.TestCase):
         c.parse(content)
         self.assertTrue("monfic.sh" in c.listAttributes)
         self.assertEqual(c.language_content(), "bash")
+    
+    def test_parser_code_block_trim_line_break(self):
+        block_code = r'''
+<file - bin/supprime-snap-désactivé.sh>
+#!/bin/sh
+LANG=C snap list --all | awk '/disabled/{print $1, $3}' |
+while read snapname revision ; do
+    snap remove "$snapname" --revision="$revision"
+done
+</file>'''
+
+        c = BlockParser(BlockParser.NAME_BLOCK_FILE)
+        c.parse(block_code)
+        content = c.get_content()
+        self.assertTrue(content.splitlines()[0], c.get_shellbang())

--- a/wiki_c/checkers/shellcode_checker.py
+++ b/wiki_c/checkers/shellcode_checker.py
@@ -5,6 +5,10 @@ import subprocess
 
 DIR_SHELLCODE_DESTINATION = 'shellcode_result'
 
+# Vous pouvez trouver la liste des erreurs
+# sur le site de shellcheck
+# https://www.shellcheck.net/wiki/
+
 class ShellCodeChecker(Checker):
     def __init__(self, full=False):
         super(ShellCodeChecker, self).__init__(DIR_SHELLCODE_DESTINATION, full)
@@ -25,6 +29,11 @@ class ShellCodeChecker(Checker):
     
     def parse_on_find_block(self, code_block_obj):
         
+        shellbang = code_block_obj.get_shellbang()
+
+        if shellbang is None:
+            return
+
         name_language = code_block_obj.language_content()
         
         if name_language not in self.SHELLCODE_ACCEPTED_LANGUAGE_NAMES:
@@ -40,6 +49,7 @@ class ShellCodeChecker(Checker):
         self.warnings += f"{result}\n\n"
     
     def parse(self, content):
+        self.warnings = ""
 
         my_parse = Parser()
 

--- a/wiki_c/parser/BlockParser.py
+++ b/wiki_c/parser/BlockParser.py
@@ -62,7 +62,7 @@ class BlockParser:
         if len(self.content) == 0:
             return None
         
-        firstLine = self.content.strip().split("\n")[0].strip()
+        firstLine = self.content.split("\n")[0].strip()
 
         # print(f"le shellbang est \"{firstLine}\"")
 
@@ -107,3 +107,8 @@ class BlockParser:
 
         self.content = content[indexFirstEnd + 1: contentLastIndex]
 
+        # le contenu doit débuter par le hashtag du shellbang
+        # si le premier caractère est un saut de ligne, on l'enlève
+        if len(self.content) > 0 and self.content[0] == '\n':
+            self.content = self.content[1:] 
+        


### PR DESCRIPTION
Le parseur prenait le contenu dès la fin du block dokuwiki. Le début du contenu du block est désormais le shellbang

Ajout d'un test.